### PR TITLE
[FE] Implement Page-based Pagination

### DIFF
--- a/apis/queries/tags/getTags.ts
+++ b/apis/queries/tags/getTags.ts
@@ -4,7 +4,7 @@ import ENDPOINTS from '../../endpoints';
 import QUERY_KEYS from '../../queryKeys';
 
 export interface Tag {
-  id: number;
+  id: string;
   name: string;
   created_at: string;
   updated_at: string;

--- a/apis/queries/tags/getTags.ts
+++ b/apis/queries/tags/getTags.ts
@@ -3,17 +3,52 @@ import { useAxios } from '../../AxiosProvider';
 import ENDPOINTS from '../../endpoints';
 import QUERY_KEYS from '../../queryKeys';
 
-const useGetTags = (search?: string) => {
+export interface Tag {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Link {
+  url: string | null;
+  label: string;
+  active: boolean;
+}
+
+export interface MetaData {
+  current_page: number;
+  from: number;
+  last_page: number;
+  links: Link[];
+  path: string;
+  per_page: number;
+  to: number;
+  total: number;
+}
+
+export interface Links {
+  first: string;
+  last: string;
+  prev: string | null;
+  next: string | null;
+}
+
+export interface TagsResponse {
+  data: Tag[];
+  links: Links;
+  meta: MetaData;
+}
+
+const useGetTags = (search?: string, page?: number) => {
   const axios = useAxios();
 
   return useQuery({
-    queryKey: [...QUERY_KEYS.TAGS.ALL, search],
+    queryKey: [...QUERY_KEYS.TAGS.ALL, search, page],
     queryFn: async () => {
-      const url = search
-        ? `${ENDPOINTS.TAGS.GET_ALL}?search=${encodeURIComponent(search)}`
-        : ENDPOINTS.TAGS.GET_ALL;
+      const url = `${ENDPOINTS.TAGS.GET_ALL}?search=${encodeURIComponent(search || '')}&page=${encodeURIComponent(page || 1)}`;
 
-      const { data } = await axios.get(url);
+      const { data } = await axios.get<TagsResponse>(url);
       return data;
     },
   });

--- a/app/content-panel/tags/page.tsx
+++ b/app/content-panel/tags/page.tsx
@@ -11,15 +11,11 @@ import AddTag from '../../../components/module-components/tags/AddTag';
 import TagManagementControls from '../../../components/module-components/tags/TagManagementControls';
 import useDebounce from '../../../utils/hooks/useDebounce';
 
-import useGetTags from '../../../apis/queries/tags/getTags';
+import useGetTags, { Tag } from '../../../apis/queries/tags/getTags';
 import useAddNewTag from '../../../apis/mutations/tags/useAddNewTag';
 import useDeleteTag from '../../../apis/mutations/tags/useDeleteTag';
 import useEditTag from '../../../apis/mutations/tags/useEditTag';
-
-interface Tag {
-  id: string;
-  name: string;
-}
+import Pagination from '../../../components/reusable-components/pagination/Pagination';
 
 const Tags = () => {
   // MUTATIONS
@@ -32,9 +28,10 @@ const Tags = () => {
   const [tags, setTags] = useState<Tag[]>([]);
   const [editingTagId, setEditingTagId] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [page, setPage] = useState(1);
 
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
-  const { data, isLoading } = useGetTags(debouncedSearchTerm);
+  const { data, isLoading } = useGetTags(debouncedSearchTerm, page);
 
   const validationSchema = Yup.object().shape({
     tagName: Yup.string()
@@ -128,6 +125,8 @@ const Tags = () => {
           </div>
         )}
       />
+
+      {data && <Pagination setPage={setPage} meta={data?.meta} />}
     </div>
   );
 };

--- a/components/reusable-components/pagination/Pagination.module.scss
+++ b/components/reusable-components/pagination/Pagination.module.scss
@@ -1,0 +1,40 @@
+.pagination {
+  gap: 3px;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 10px;
+}
+
+.paginationButton {
+  border-radius: 10px;
+  border: none;
+  padding: 3px;
+  width: 40px;
+  height: 40px;
+
+  &:disabled {
+    cursor: not-allowed;
+    color: black;
+    background-color: white;
+    opacity: 20%;
+  }
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--primary-btn-hover-color);
+    color: white;
+
+    &:disabled {
+      cursor: not-allowed;
+      color: black;
+      background-color: white;
+    }
+  }
+}
+
+.selectedPaginationButton {
+  @extend .paginationButton;
+  background-color: var(--primary-btn-active-color);
+  color: white;
+}

--- a/components/reusable-components/pagination/Pagination.tsx
+++ b/components/reusable-components/pagination/Pagination.tsx
@@ -1,8 +1,5 @@
 /* eslint-disable camelcase */
 
-// This component expects to receive meta object that contains the links
-// as well as pagination data. See types for more details on what's expected.
-
 import React from 'react';
 import styles from './Pagination.module.scss';
 import { MetaData } from '../../../apis/queries/tags/getTags';
@@ -14,7 +11,7 @@ interface PaginationProps {
 
 const Pagination: React.FC<PaginationProps> = ({ meta, setPage }) => {
   const { current_page, last_page } = meta;
-  const pages = Array.from({ length: last_page }, (_, i) => i + 1); // create array with page numbers [1, 2...]
+  const pages = Array.from({ length: last_page }, (_, i) => i + 1);
 
   if (meta) {
     return (

--- a/components/reusable-components/pagination/Pagination.tsx
+++ b/components/reusable-components/pagination/Pagination.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable camelcase */
+
+// This component expects to receive meta object that contains the links
+// as well as pagination data. See types for more details.
+
+import React from 'react';
+import { MetaData } from '../../../apis/queries/tags/getTags';
+
+interface PaginationProps {
+  meta: MetaData;
+  setPage: (page: number) => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ meta, setPage }) => {
+  const { links, current_page, last_page } = meta;
+  const pages = Array.from({ length: last_page }, (_, i) => i + 1); // create array with page numbers [1, 2...]
+
+  if (links?.length > 0) {
+    return (
+      <div className="pagination">
+        <button
+          type="button"
+          onClick={() => setPage(current_page - 1)}
+          disabled={current_page === 1}
+        >
+          &lt;
+        </button>
+
+        {pages.map((page) => (
+          <button
+            type="button"
+            key={page}
+            onClick={() => setPage(page)}
+            disabled={current_page === page}
+          >
+            {page}
+          </button>
+        ))}
+
+        <button
+          type="button"
+          onClick={() => setPage(current_page + 1)}
+          disabled={current_page === last_page}
+        >
+          &gt;
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default Pagination;

--- a/components/reusable-components/pagination/Pagination.tsx
+++ b/components/reusable-components/pagination/Pagination.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable camelcase */
 
 // This component expects to receive meta object that contains the links
-// as well as pagination data. See types for more details.
+// as well as pagination data. See types for more details on what's expected.
 
 import React from 'react';
+import styles from './Pagination.module.scss';
 import { MetaData } from '../../../apis/queries/tags/getTags';
 
 interface PaginationProps {
@@ -12,13 +13,14 @@ interface PaginationProps {
 }
 
 const Pagination: React.FC<PaginationProps> = ({ meta, setPage }) => {
-  const { links, current_page, last_page } = meta;
+  const { current_page, last_page } = meta;
   const pages = Array.from({ length: last_page }, (_, i) => i + 1); // create array with page numbers [1, 2...]
 
-  if (links?.length > 0) {
+  if (meta) {
     return (
-      <div className="pagination">
+      <div className={styles.pagination}>
         <button
+          className={styles.paginationButton}
           type="button"
           onClick={() => setPage(current_page - 1)}
           disabled={current_page === 1}
@@ -28,16 +30,17 @@ const Pagination: React.FC<PaginationProps> = ({ meta, setPage }) => {
 
         {pages.map((page) => (
           <button
+            className={`${current_page === page ? styles.selectedPaginationButton : styles.paginationButton}`}
             type="button"
             key={page}
             onClick={() => setPage(page)}
-            disabled={current_page === page}
           >
             {page}
           </button>
         ))}
 
         <button
+          className={styles.paginationButton}
           type="button"
           onClick={() => setPage(current_page + 1)}
           disabled={current_page === last_page}


### PR DESCRIPTION
This PR introduces a reusable page-based pagination component for tables (such as blogs, tags, etc.). It relies on the backend's pagination implementation, which returns a meta object, as shown below.

Instead of using the `links` array, we calculate the number of pages using `current_page` and `last_page`. This approach offers a simpler implementation and greater flexibility for customization.

Additionally, the tags query has been updated to include all relevant interfaces, with added support for passing a "page" query parameter in the request.

**p.s Needs content-manager permissions (bearer token set to .env) to test.**

Example meta object returned from backend:

```javascript
"meta": {
        "current_page": 1,
        "from": 1,
        "last_page": 2,
        "links": [
            {
                "url": null,
                "label": "« Претходна",
                "active": false
            },
            {
                "url": "https://staging-api.learnhub.mk/content/blog-post-tags?page=1",
                "label": "1",
                "active": true
            },
            {
                "url": "https://staging-api.learnhub.mk/content/blog-post-tags?page=2",
                "label": "2",
                "active": false
            },
            {
                "url": "https://staging-api.learnhub.mk/content/blog-post-tags?page=2",
                "label": "Следна »",
                "active": false
            }
        ],
        "path": "https://staging-api.learnhub.mk/content/blog-post-tags",
        "per_page": 20,
        "to": 20,
        "total": 24
    }
```