### PR TITLE
[FE] Admin-Panel: Members Management - View, Search, and Filter User List

### DIFF
--- a/apis/endpoints.ts
+++ b/apis/endpoints.ts
@@ -24,6 +24,9 @@ const ENDPOINTS = {
     DELETE: `${API_BASE_URL}/content/blog-post-tags`,
     EDIT: `${API_BASE_URL}/content/blog-post-tags`,
   },
+  MEMBERS: {
+    GET_ALL: `${API_BASE_URL}/admin/members`,
+  },
 };
 
 export default ENDPOINTS;

--- a/apis/queries/members/buildMembersUrl.ts
+++ b/apis/queries/members/buildMembersUrl.ts
@@ -1,0 +1,18 @@
+const buildMembersUrl = (
+  baseUrl: string,
+  paginationPage: number,
+  sort: { sortDirection: string; sortBy: string },
+  search: string
+) => {
+  const params = new URLSearchParams({
+    per_page: '5',
+    page: paginationPage.toString(),
+    sort_direction: sort.sortDirection,
+    sort_by: sort.sortBy,
+    query: search,
+  });
+
+  return `${baseUrl}?${params.toString()}`;
+};
+
+export default buildMembersUrl;

--- a/apis/queries/members/getMembers.ts
+++ b/apis/queries/members/getMembers.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAxios } from '../../AxiosProvider';
+import ENDPOINTS from '../../endpoints';
+import QUERY_KEYS from '../../queryKeys';
+import { MemberResponse } from './types';
+import { transformMembersResponse } from './transformMembersResponse';
+
+const useGetMembers = ({ initialData }: { initialData: MemberResponse }) => {
+  const axios = useAxios();
+
+  return useQuery({
+    queryKey: QUERY_KEYS.MEMBERS.ALL,
+    queryFn: async () => {
+      const { data } = await axios.get<MemberResponse>(ENDPOINTS.MEMBERS.GET_ALL);
+      return transformMembersResponse(data);
+    },
+    initialData,
+  });
+};
+
+export default useGetMembers;

--- a/apis/queries/members/getMembers.ts
+++ b/apis/queries/members/getMembers.ts
@@ -5,13 +5,18 @@ import QUERY_KEYS from '../../queryKeys';
 import { MemberResponse } from './types';
 import { transformMembersResponse } from './transformMembersResponse';
 
-const useGetMembers = ({ initialData }: { initialData: MemberResponse }) => {
+const useGetMembers = (
+  { initialData }: { initialData: MemberResponse },
+  paginationPage: number
+) => {
   const axios = useAxios();
 
   return useQuery({
-    queryKey: QUERY_KEYS.MEMBERS.ALL,
+    queryKey: [...QUERY_KEYS.MEMBERS.ALL, paginationPage],
     queryFn: async () => {
-      const { data } = await axios.get<MemberResponse>(ENDPOINTS.MEMBERS.GET_ALL);
+      const { data } = await axios.get<MemberResponse>(
+        `${ENDPOINTS.MEMBERS.GET_ALL}?per_page=5&page=${paginationPage}`
+      );
       return transformMembersResponse(data);
     },
     initialData,

--- a/apis/queries/members/getMembers.ts
+++ b/apis/queries/members/getMembers.ts
@@ -7,15 +7,19 @@ import { transformMembersResponse } from './transformMembersResponse';
 
 const useGetMembers = (
   { initialData }: { initialData: MemberResponse },
-  paginationPage: number
+  paginationPage: number,
+  sort: {
+    sortDirection: string;
+    sortBy: string;
+  }
 ) => {
   const axios = useAxios();
 
   return useQuery({
-    queryKey: [...QUERY_KEYS.MEMBERS.ALL, paginationPage],
+    queryKey: [...QUERY_KEYS.MEMBERS.ALL, paginationPage, sort],
     queryFn: async () => {
       const { data } = await axios.get<MemberResponse>(
-        `${ENDPOINTS.MEMBERS.GET_ALL}?per_page=5&page=${paginationPage}`
+        `${ENDPOINTS.MEMBERS.GET_ALL}?per_page=5&page=${paginationPage}&sort_direction=${sort.sortDirection}&sort_by=${sort.sortBy}`
       );
       return transformMembersResponse(data);
     },

--- a/apis/queries/members/getMembers.ts
+++ b/apis/queries/members/getMembers.ts
@@ -2,8 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { useAxios } from '../../AxiosProvider';
 import ENDPOINTS from '../../endpoints';
 import QUERY_KEYS from '../../queryKeys';
-import { MemberResponse } from './types';
 import { transformMembersResponse } from './transformMembersResponse';
+import buildMembersUrl from './buildMembersUrl';
+import { MemberResponse } from './types';
 
 const useGetMembers = (
   { initialData }: { initialData: MemberResponse },
@@ -11,16 +12,16 @@ const useGetMembers = (
   sort: {
     sortDirection: string;
     sortBy: string;
-  }
+  },
+  search: string
 ) => {
   const axios = useAxios();
 
   return useQuery({
-    queryKey: [...QUERY_KEYS.MEMBERS.ALL, paginationPage, sort],
+    queryKey: [...QUERY_KEYS.MEMBERS.ALL, paginationPage, sort, search],
     queryFn: async () => {
-      const { data } = await axios.get<MemberResponse>(
-        `${ENDPOINTS.MEMBERS.GET_ALL}?per_page=5&page=${paginationPage}&sort_direction=${sort.sortDirection}&sort_by=${sort.sortBy}`
-      );
+      const url = buildMembersUrl(ENDPOINTS.MEMBERS.GET_ALL, paginationPage, sort, search);
+      const { data } = await axios.get<MemberResponse>(url);
       return transformMembersResponse(data);
     },
     initialData,

--- a/apis/queries/members/transformMembersResponse.ts
+++ b/apis/queries/members/transformMembersResponse.ts
@@ -1,0 +1,22 @@
+export const transformMemberData = (rawMember: any) => ({
+  id: rawMember.id,
+  updated_at: rawMember.updated_at,
+  first_name: rawMember.profile.first_name,
+  last_name: rawMember.profile.last_name,
+  image: rawMember.profile.image,
+  email: rawMember.email,
+  status: rawMember.status,
+  role: rawMember.role,
+  profile: {
+    id: rawMember.profile.id,
+    created_at: rawMember.profile.created_at,
+    updated_at: rawMember.profile.updated_at,
+  },
+  created_at: rawMember.created_at,
+});
+
+export const transformMembersResponse = (response: any) => ({
+  data: response.data.map(transformMemberData),
+  links: response.links,
+  meta: response.meta,
+});

--- a/apis/queries/members/types.ts
+++ b/apis/queries/members/types.ts
@@ -1,0 +1,65 @@
+export type Profile = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  image: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TransformedMember = {
+  id: string;
+  updated_at: string;
+  first_name: string;
+  last_name: string;
+  image: string | null;
+  email: string;
+  status: string;
+  role: string;
+  profile: {
+    id: string;
+    created_at: string;
+    updated_at: string;
+  };
+  created_at: string;
+};
+
+export type Member = {
+  id: string;
+  email: string;
+  status: string;
+  role: string;
+  profile: Profile;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PaginationLink = {
+  url: string | null;
+  label: string;
+  active: boolean;
+};
+
+export type Links = {
+  first: string;
+  last: string;
+  prev: string | null;
+  next: string | null;
+};
+
+export type Meta = {
+  current_page: number;
+  from: number;
+  last_page: number;
+  links: PaginationLink[];
+  path: string;
+  per_page: number;
+  to: number;
+  total: number;
+};
+
+export type MemberResponse = {
+  data: Member[];
+  links: Links;
+  meta: Meta;
+};

--- a/apis/queryKeys.ts
+++ b/apis/queryKeys.ts
@@ -9,6 +9,9 @@ const QUERY_KEYS = {
   TAGS: {
     ALL: ['blogPostTags'],
   },
+  MEMBERS: {
+    ALL: ['members'],
+  },
 } as const;
 
 export default QUERY_KEYS;

--- a/app/admin-dashboard/page.tsx
+++ b/app/admin-dashboard/page.tsx
@@ -1,5 +1,0 @@
-const AdminDashboardPage = () => {
-  return <div>AdminDashboardPage</div>;
-};
-
-export default AdminDashboardPage;

--- a/app/admin-panel/manage-members/page.tsx
+++ b/app/admin-panel/manage-members/page.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import MemberManagementClient from '../../../components/module-components/admin-panel/MemberManagementClient';
+import axiosInstance from '../../../apis/axiosInstance';
+import { transformMembersResponse } from '../../../apis/queries/members/transformMembersResponse';
+import ENDPOINTS from '../../../apis/endpoints';
+
+const page = async () => {
+  const response = await axiosInstance.get(ENDPOINTS.MEMBERS.GET_ALL);
+  const transformedData = transformMembersResponse(response.data);
+
+  return <MemberManagementClient initialData={transformedData} />;
+};
+
+export default page;

--- a/app/admin-panel/manage-members/page.tsx
+++ b/app/admin-panel/manage-members/page.tsx
@@ -5,7 +5,7 @@ import { transformMembersResponse } from '../../../apis/queries/members/transfor
 import ENDPOINTS from '../../../apis/endpoints';
 
 const page = async () => {
-  const response = await axiosInstance.get(ENDPOINTS.MEMBERS.GET_ALL);
+  const response = await axiosInstance.get(`${ENDPOINTS.MEMBERS.GET_ALL}?per_page=5`);
   const transformedData = transformMembersResponse(response.data);
 
   return <MemberManagementClient initialData={transformedData} />;

--- a/components/module-components/admin-panel/MemberManagementClient.module.scss
+++ b/components/module-components/admin-panel/MemberManagementClient.module.scss
@@ -1,0 +1,9 @@
+.mainContainer {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.table {
+  width: 60%;
+}

--- a/components/module-components/admin-panel/MemberManagementClient.module.scss
+++ b/components/module-components/admin-panel/MemberManagementClient.module.scss
@@ -1,9 +1,34 @@
+@import '../../../app/styles/utils/breakpoints.scss';
+
 .mainContainer {
+  padding: 20px;
   display: flex;
   justify-content: center;
   width: 100%;
 }
 
 .table {
-  width: 60%;
+  padding: 10px;
+  width: 100%;
+
+  @include breakpoint(small) {
+    width: 80%;
+  }
+
+  @include breakpoint(medium) {
+    width: 60%;
+  }
+}
+
+.searchInputWrapper {
+  width: 100%;
+}
+
+.searchAndSort {
+  display: flex;
+  gap: 10px;
+  height: 40px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: stretch;
 }

--- a/components/module-components/admin-panel/MemberManagementClient.tsx
+++ b/components/module-components/admin-panel/MemberManagementClient.tsx
@@ -2,15 +2,18 @@
 
 import React, { useState } from 'react';
 import Loading from '../../../app/loading';
-import ReusableTable from '../../reusable-components/reusable-table/ReusableTable';
+import MembersTable from '../../reusable-components/reusable-table/ReusableTable';
 import useGetMembers from '../../../apis/queries/members/getMembers';
 import { MemberResponse, TransformedMember } from '../../../apis/queries/members/types';
 import styles from './MemberManagementClient.module.scss';
 import Pagination from '../../reusable-components/pagination/Pagination';
+import sortActions from './sortActions';
+import SortButton from '../../reusable-components/reusable-dropdown/ReusableDropdown';
 
 const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }) => {
   const [paginationPage, setPaginationPage] = useState(1);
-  const { data, isLoading, isError } = useGetMembers({ initialData }, paginationPage);
+  const [sort, setSort] = useState({ sortBy: '', sortDirection: '' });
+  const { data, isLoading, isError } = useGetMembers({ initialData }, paginationPage, sort);
   const headers: (keyof TransformedMember)[] = [
     'first_name',
     'last_name',
@@ -32,7 +35,8 @@ const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }
   return (
     <div className={styles.mainContainer}>
       <div className={styles.table}>
-        <ReusableTable<TransformedMember>
+        <SortButton items={sortActions(setSort)} placeholder="Сортирај" />
+        <MembersTable<TransformedMember>
           isLoading={isLoading}
           headers={headers}
           displayNames={displayNames}

--- a/components/module-components/admin-panel/MemberManagementClient.tsx
+++ b/components/module-components/admin-panel/MemberManagementClient.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import Loading from '../../../app/loading';
+import ReusableTable from '../../reusable-components/reusable-table/ReusableTable';
+import useGetMembers from '../../../apis/queries/members/getMembers';
+import { MemberResponse, TransformedMember } from '../../../apis/queries/members/types';
+import styles from './MemberManagementClient.module.scss';
+
+const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }) => {
+  const { data, isLoading, isError } = useGetMembers({ initialData });
+  const headers: (keyof TransformedMember)[] = [
+    'first_name',
+    'last_name',
+    'email',
+    'status',
+    'role',
+  ];
+  const displayNames = {
+    first_name: 'Име',
+    last_name: 'Презиме',
+    email: 'Email',
+    status: 'Статус',
+    role: 'Улога',
+  };
+
+  if (isLoading) return <Loading />;
+  if (isError) return <div>Sorry, There was an Error</div>;
+
+  return (
+    <div className={styles.mainContainer}>
+      <div className={styles.table}>
+        <ReusableTable<TransformedMember>
+          isLoading={isLoading}
+          headers={headers}
+          displayNames={displayNames}
+          data={data.data}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MemberManagementClient;

--- a/components/module-components/admin-panel/MemberManagementClient.tsx
+++ b/components/module-components/admin-panel/MemberManagementClient.tsx
@@ -8,10 +8,12 @@ import { MemberResponse, TransformedMember } from '../../../apis/queries/members
 import styles from './MemberManagementClient.module.scss';
 import Pagination from '../../reusable-components/pagination/Pagination';
 import sortActions from './sortActions';
-import SortButton from '../../reusable-components/reusable-dropdown/ReusableDropdown';
+import SortDropdown from '../../reusable-components/reusable-dropdown/ReusableDropdown';
+import Input from '../../reusable-components/input/Input';
 
 const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }) => {
   const [paginationPage, setPaginationPage] = useState(1);
+  const [searchTerm, setSearchTerm] = useState('');
   const [sort, setSort] = useState({ sortBy: '', sortDirection: '' });
   const { data, isLoading, isError } = useGetMembers({ initialData }, paginationPage, sort);
   const headers: (keyof TransformedMember)[] = [
@@ -35,7 +37,23 @@ const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }
   return (
     <div className={styles.mainContainer}>
       <div className={styles.table}>
-        <SortButton items={sortActions(setSort)} placeholder="Сортирај" />
+        <div className={styles.searchAndSort}>
+          <div className={styles.searchInputWrapper}>
+            <Input
+              type="text"
+              placeholder="Пребарувај по име, презиме, email"
+              value={searchTerm}
+              onChange={setSearchTerm}
+            />
+          </div>
+
+          <SortDropdown
+            items={sortActions(setSort)}
+            placeholder="Сортирај"
+            icon={<i className="bi bi-caret-down" />}
+          />
+        </div>
+
         <MembersTable<TransformedMember>
           isLoading={isLoading}
           headers={headers}

--- a/components/module-components/admin-panel/MemberManagementClient.tsx
+++ b/components/module-components/admin-panel/MemberManagementClient.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import Loading from '../../../app/loading';
 import ReusableTable from '../../reusable-components/reusable-table/ReusableTable';
 import useGetMembers from '../../../apis/queries/members/getMembers';
 import { MemberResponse, TransformedMember } from '../../../apis/queries/members/types';
 import styles from './MemberManagementClient.module.scss';
+import Pagination from '../../reusable-components/pagination/Pagination';
 
 const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }) => {
-  const { data, isLoading, isError } = useGetMembers({ initialData });
+  const [paginationPage, setPaginationPage] = useState(1);
+  const { data, isLoading, isError } = useGetMembers({ initialData }, paginationPage);
   const headers: (keyof TransformedMember)[] = [
     'first_name',
     'last_name',
@@ -36,6 +38,8 @@ const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }
           displayNames={displayNames}
           data={data.data}
         />
+
+        <Pagination meta={data.meta} setPage={setPaginationPage} />
       </div>
     </div>
   );

--- a/components/module-components/admin-panel/MemberManagementClient.tsx
+++ b/components/module-components/admin-panel/MemberManagementClient.tsx
@@ -10,12 +10,19 @@ import Pagination from '../../reusable-components/pagination/Pagination';
 import sortActions from './sortActions';
 import SortDropdown from '../../reusable-components/reusable-dropdown/ReusableDropdown';
 import Input from '../../reusable-components/input/Input';
+import useDebounce from '../../../utils/hooks/useDebounce';
 
 const MemberManagementClient = ({ initialData }: { initialData: MemberResponse }) => {
   const [paginationPage, setPaginationPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState('');
   const [sort, setSort] = useState({ sortBy: '', sortDirection: '' });
-  const { data, isLoading, isError } = useGetMembers({ initialData }, paginationPage, sort);
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
+  const { data, isLoading, isError } = useGetMembers(
+    { initialData },
+    paginationPage,
+    sort,
+    debouncedSearchTerm
+  );
   const headers: (keyof TransformedMember)[] = [
     'first_name',
     'last_name',

--- a/components/module-components/admin-panel/sortActions.ts
+++ b/components/module-components/admin-panel/sortActions.ts
@@ -1,0 +1,64 @@
+type SetSort = (params: { sortBy: string; sortDirection: string }) => void;
+
+const sortActions = (setSort: SetSort) => {
+  const actions = [
+    {
+      id: 1,
+      label: 'Име (растечки)',
+      onClick: () =>
+        setSort({
+          sortBy: 'first_name',
+          sortDirection: 'asc',
+        }),
+    },
+    {
+      id: 2,
+      label: 'Име (опаѓачки)',
+      onClick: () =>
+        setSort({
+          sortBy: 'first_name',
+          sortDirection: 'desc',
+        }),
+    },
+    {
+      id: 3,
+      label: 'Email (растечки)',
+      onClick: () =>
+        setSort({
+          sortBy: 'email',
+          sortDirection: 'asc',
+        }),
+    },
+    {
+      id: 4,
+      label: 'Email (опаѓачки)',
+      onClick: () =>
+        setSort({
+          sortBy: 'email',
+          sortDirection: 'desc',
+        }),
+    },
+    {
+      id: 5,
+      label: 'Улога (растечки)',
+      onClick: () =>
+        setSort({
+          sortBy: 'role',
+          sortDirection: 'asc',
+        }),
+    },
+    {
+      id: 6,
+      label: 'Улога (опаѓачки)',
+      onClick: () =>
+        setSort({
+          sortBy: 'role',
+          sortDirection: 'desc',
+        }),
+    },
+  ];
+
+  return actions;
+};
+
+export default sortActions;

--- a/components/reusable-components/input/input.module.scss
+++ b/components/reusable-components/input/input.module.scss
@@ -1,16 +1,20 @@
 @import '../../../app/styles/utils/breakpoints.scss';
 
 .inputWrapp {
+  height: 100%;
   width: 100%;
 }
 
 .inputContainer {
+  height: 100%;
+
   display: flex;
   align-items: center;
   width: 100%;
 }
 
 .input {
+  height: 100%;
   padding: 8px;
   font-size: 16px;
   border: 1px solid #ccc;

--- a/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
+++ b/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
@@ -1,0 +1,57 @@
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.dropdownButton {
+  font-size: var(--fs-button);
+  font-weight: 400;
+  background-color: #ffffff;
+  color: #333;
+  padding: 10px 15px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.dropdownButton:hover {
+  background-color: #f7f7f7;
+}
+
+.dropdownList {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background-color: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  list-style: none;
+  margin: 5px 0 0;
+  padding: 5px 0;
+  width: 200px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.dropdownItem {
+  padding: 0;
+}
+
+.dropdownItem:hover {
+  background-color: #f0f0f0;
+}
+
+.dropdownItemButton {
+  background: none;
+  border: none;
+  padding: 10px 15px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.dropdownItemButton:hover {
+  background-color: #f0f0f0;
+}

--- a/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
+++ b/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
@@ -4,6 +4,9 @@
 }
 
 .dropdownButton {
+  height: 100%;
+  display: flex;
+  justify-content: end;
   font-size: var(--fs-button);
   font-weight: 400;
   background-color: #ffffff;

--- a/components/reusable-components/reusable-dropdown/ReusableDropdown.tsx
+++ b/components/reusable-components/reusable-dropdown/ReusableDropdown.tsx
@@ -10,9 +10,10 @@ type DropdownItem = {
 type DropdownProps = {
   items: DropdownItem[];
   placeholder?: string;
+  icon?: React.ReactNode;
 };
 
-const Dropdown: React.FC<DropdownProps> = ({ items, placeholder = 'Select an option' }) => {
+const Dropdown: React.FC<DropdownProps> = ({ items, placeholder = 'Select an option', icon }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -41,6 +42,7 @@ const Dropdown: React.FC<DropdownProps> = ({ items, placeholder = 'Select an opt
     <div className={styles.dropdown} ref={dropdownRef}>
       <button type="button" onClick={toggleDropdown} className={styles.dropdownButton}>
         {placeholder}
+        {icon && <span>{icon}</span>}
       </button>
       {isOpen && (
         <ul className={styles.dropdownList}>

--- a/components/reusable-components/reusable-dropdown/ReusableDropdown.tsx
+++ b/components/reusable-components/reusable-dropdown/ReusableDropdown.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef } from 'react';
+import styles from './ReusableDropdown.module.scss';
+
+type DropdownItem = {
+  id: number;
+  label: string;
+  onClick: () => void;
+};
+
+type DropdownProps = {
+  items: DropdownItem[];
+  placeholder?: string;
+};
+
+const Dropdown: React.FC<DropdownProps> = ({ items, placeholder = 'Select an option' }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const toggleDropdown = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleItemClick = (onClick: () => void) => {
+    onClick();
+    setIsOpen(false);
+  };
+
+  return (
+    <div className={styles.dropdown} ref={dropdownRef}>
+      <button type="button" onClick={toggleDropdown} className={styles.dropdownButton}>
+        {placeholder}
+      </button>
+      {isOpen && (
+        <ul className={styles.dropdownList}>
+          {items.map((item) => (
+            <li key={item.id} className={styles.dropdownItem}>
+              <button
+                type="button"
+                className={styles.dropdownItemButton}
+                onClick={() => handleItemClick(item.onClick)}
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/components/reusable-components/reusable-table/ActionDropdown.tsx
+++ b/components/reusable-components/reusable-table/ActionDropdown.tsx
@@ -6,7 +6,7 @@ import style from './actionDropdown.module.scss';
 interface DropdownItem {
   id: string;
   label: string;
-  onClick: () => {};
+  onClick: () => void;
 }
 interface ActionDropdownProps {
   dropdownItems: DropdownItem[];

--- a/components/reusable-components/reusable-table/ActionDropdown.tsx
+++ b/components/reusable-components/reusable-table/ActionDropdown.tsx
@@ -6,7 +6,7 @@ import style from './actionDropdown.module.scss';
 interface DropdownItem {
   id: string;
   label: string;
-  onClick?: () => void;
+  onClick: () => {};
 }
 interface ActionDropdownProps {
   dropdownItems: DropdownItem[];
@@ -20,6 +20,11 @@ const ActionDropdown = ({ dropdownItems }: ActionDropdownProps) => {
     if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
       setIsOpen(false);
     }
+  };
+
+  const handleClick = (item: DropdownItem) => {
+    setIsOpen(!isOpen);
+    item.onClick();
   };
 
   useEffect(() => {
@@ -38,7 +43,12 @@ const ActionDropdown = ({ dropdownItems }: ActionDropdownProps) => {
         <ul className={style.dropdownMenu}>
           {dropdownItems.map((item) => (
             <li key={item.id} className={style.dropdownItem}>
-              <button type="button" onClick={item.onClick}>
+              <button
+                type="button"
+                onClick={() => {
+                  handleClick(item);
+                }}
+              >
                 {item.label}
               </button>
             </li>

--- a/components/reusable-components/reusable-table/ReusableTable.tsx
+++ b/components/reusable-components/reusable-table/ReusableTable.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo } from 'react';
 import TableRowComponent from './TableRowComponent';
 import style from './reusableTable.module.scss';
 import TableHead from './TableHead';
+import Loading from '../../../app/loading';
 
 interface ReusableTableProps<T> {
   headers: (keyof T)[];
@@ -60,7 +61,7 @@ const ReusableTable = <T extends { id: string }>({
   }, [data, sortState]);
 
   if (isLoading) {
-    return <div className={style.noDataMessage}>Се вчитува</div>;
+    return <Loading />;
   }
 
   if (!isLoading && data?.length === 0) {

--- a/components/reusable-components/reusable-table/actionDropdown.module.scss
+++ b/components/reusable-components/reusable-table/actionDropdown.module.scss
@@ -1,12 +1,12 @@
 .dropdown {
   position: relative;
-
+  width: fit-content;
   .dropdownMenu {
     display: block;
     position: absolute;
     background-color: white;
     box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.2);
-    z-index: 1;
+    z-index: 100;
     margin-top: 5px;
     border-radius: 4px;
     min-width: 120px;
@@ -16,9 +16,9 @@
       border: none;
       background-color: inherit;
       padding: 10px;
-      cursor: pointer;
       list-style: none;
       text-align: left;
+      text-wrap: nowrap;
     }
   }
 }

--- a/components/reusable-components/reusable-table/reusableTable.module.scss
+++ b/components/reusable-components/reusable-table/reusableTable.module.scss
@@ -13,12 +13,12 @@ $table-height: 400px;
     width: 100%;
     border-collapse: collapse;
     text-align: left;
-    text-indent: 1rem;
 
-    thead {
-      position: sticky;
-      top: 0;
-      z-index: 1;
+    th {
+      padding: 15px;
+      white-space: nowrap;
+      text-align: left;
+      overflow: hidden;
     }
 
     td {

--- a/components/reusable-components/reusable-table/reusableTable.module.scss
+++ b/components/reusable-components/reusable-table/reusableTable.module.scss
@@ -1,6 +1,7 @@
 $table-height: 400px;
 
 .tableWrapper {
+  border-radius: 8px;
   margin-block: 1.5rem;
   border: 1px solid #94a3b8;
   background-color: #f8fafc;
@@ -42,7 +43,7 @@ $table-height: 400px;
 
 .noDataMessage {
   height: $table-height;
-  background-color: #ec4f1e;
+  background-color: var(--primary-btn-active-color);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/reusable-components/reusable-table/tableHead.module.scss
+++ b/components/reusable-components/reusable-table/tableHead.module.scss
@@ -1,12 +1,14 @@
 .tableHead {
-  background-color: #ec4f1e;
+  background-color: var(--primary-btn-active-color);
 }
 
 .tableHeaderCell {
+  width: 100%;
   padding: 10px 10px 10px 0;
   text-align: left;
   cursor: pointer;
   border-bottom: 1px solid #ddd;
+  white-space: nowrap;
 }
 
 .sortArrow {

--- a/components/reusable-components/reusable-table/tableHead.module.scss
+++ b/components/reusable-components/reusable-table/tableHead.module.scss
@@ -4,7 +4,7 @@
 
 .tableHeaderCell {
   width: 100%;
-  padding: 10px 10px 10px 0;
+  padding: 15px 25px;
   text-align: left;
   cursor: pointer;
   border-bottom: 1px solid #ddd;

--- a/components/reusable-components/reusable-table/tableRowComponent.module.scss
+++ b/components/reusable-components/reusable-table/tableRowComponent.module.scss
@@ -4,7 +4,7 @@
   max-height: 40px;
 
   td {
-    padding: 0;
+    padding: 15px;
     vertical-align: middle;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
## Summary of Changes

- Implemented an admin panel for managing members. This allows admins to:
  - List, search, and sort members.
  - Enhance the user experience through improved table styling.
- Created a reusable dropdown component for consistent and modular UI.

## Splash Damage

- UI changes might affect other components where `<ReusableTable />` is rendered. These should be tested for regressions.

## Limitations and Future Work

- Filtering is not implemented yet due to backend unavailability. Once the backend supports this, it can be added in a future PR.
- Currently, the search functionality only works for the first and last names. Email search is not yet supported.

## Manual Test Steps

1. **Setup**:
   - Clone the repository and check out the feature branch.
   - Run `npm install` to install dependencies.
   - Obtain an admin bearer token from the API: [API Documentation Link](https://staging-api.learnhub.mk/docs/#authentication-POSTadmin-login).
   - Set the token in your `.env` file:
     ```env
     NEXT_PUBLIC_BEARER=[OBTAINED TOKEN HERE]
     ```
2. **Verify Functionality**:
   - Navigate to `http://localhost:3000/admin-panel/manage-members`.
   - Confirm the following features are working as expected:
     - Fetching member data.
     - Search functionality for first and last names.
     - Pagination and sorting.
   - Test responsiveness on different screen sizes.
