### PR TITLE
fix (invisible actions menu): actions menu is correctly displayed

### DIFF
--- a/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
+++ b/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
@@ -63,3 +63,9 @@
 .dropdownItemButton:hover {
   background-color: #f0f0f0;
 }
+
+tbody tr:last-child .dropdownList {
+  top: auto;
+  bottom: 100%;
+  margin-bottom: 5px;
+}

--- a/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
+++ b/components/reusable-components/reusable-dropdown/ReusableDropdown.module.scss
@@ -64,7 +64,8 @@
   background-color: #f0f0f0;
 }
 
-tbody tr:last-child .dropdownList {
+tbody tr:last-child .dropdownList,
+tbody tr:nth-last-child(2) .dropdownList {
   top: auto;
   bottom: 100%;
   margin-bottom: 5px;


### PR DESCRIPTION
The actions menu on the last blog post on the list is no longer invisible, promting the user to scroll a bit more down. Instead it faces upward.